### PR TITLE
Made require fail gracefully for gulp

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function runSequence(gulp) {
 	runNextSet();
 }
 
-module.exports = runSequence.bind(null, require('gulp'));
+module.exports = runSequence.bind(null, require.resolve('gulp'));
 module.exports.use = function(gulp) {
 	return runSequence.bind(null, gulp);
 };


### PR DESCRIPTION
When calling require("run-sequence).use(gulp), run-sequence is being constructed prior to the use() method being called.  Therefore, the require("gulp") call is getting fired.  We should use require.resolve() to prevent this from throwing an exception for those wanting to use the use() method.  Otherwise, gulp should be optionally passed into the constructor as an argument.  Unfortunately, this module isn't written with a well defined constructor, so that'd be a fair bit of rewriting.
