### PR TITLE
Fix problem when an array variable is passed as argument to runSequence

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,18 @@ function verifyTaskSets(gulp, taskSets, skipArrays) {
 }
 
 function runSequence(gulp) {
-	var taskSets = Array.prototype.slice.call(arguments, 1),
+	var runSequenceArgs = arguments,
+		taskSets = (function() {
+			var clonedTaskSets = [];
+			Array.prototype.slice.call(runSequenceArgs, 1).forEach(function(entry) {
+				if (Array.isArray(entry)) {
+					clonedTaskSets.push(JSON.parse(JSON.stringify(entry)));
+				} else {
+					clonedTaskSets.push(entry);
+				}
+			});
+			return clonedTaskSets;
+		}()),
 		callBack = typeof taskSets[taskSets.length-1] === 'function' ? taskSets.pop() : false,
 		currentTaskSet,
 

--- a/test/main.js
+++ b/test/main.js
@@ -71,7 +71,12 @@ describe('runSequence', function() {
 			task4.counter.should.eql(3);
 			//noinspection BadExpressionStatementJS
 			wasCalled.should.be.true;
-		})
+		});
+		it('should not change the passed task array', function() {
+			var taskArray = ['task1', 'task2'];
+			runSequence(taskArray);
+			taskArray.should.eql(['task1', 'task2']);
+		});
 	});
 
 	describe('Asynchronous Tasks', function() {


### PR DESCRIPTION
Please have a look at the new test, without my change the passed variable "taskArray" would be an empty array after the runSequence call.
