### PR TITLE
Update finish callback to handle errors properly.

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ function runSequence(gulp) {
 			gulp.removeListener('task_stop', onTaskEnd);
 			gulp.removeListener('task_err', onError);
 			if(callBack) {
-				callBack(e.err);
-			} else if(e.err) {
+				callBack(e && e.err ? e.err : undefined);
+			} else if(e && e.err) {
 				console.log(colors.red('Error running task sequence:'), e.err);
 			}
 		},

--- a/index.js
+++ b/index.js
@@ -46,13 +46,13 @@ function runSequence(gulp) {
 		callBack = typeof taskSets[taskSets.length-1] === 'function' ? taskSets.pop() : false,
 		currentTaskSet,
 
-		finish = function(err) {
+		finish = function(e) {
 			gulp.removeListener('task_stop', onTaskEnd);
 			gulp.removeListener('task_err', onError);
 			if(callBack) {
-				callBack(err);
-			} else if(err) {
-				console.log(colors.red('Error running task sequence:'), err);
+				callBack(e.err);
+			} else if(e.err) {
+				console.log(colors.red('Error running task sequence:'), e.err);
 			}
 		},
 


### PR DESCRIPTION
Errors emitted by orchestrator are wrapped in another object. Instead of passing this object to the callback, we pass the err object it contains.