### PR TITLE
Generalize error passed to callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function runSequence(gulp) {
 			if (e && e.err) {
 				error = new gutil.PluginError('run-sequence', { 
 					message: 'An error occured in task "' + e.task + '".'
-				})
+				});
 			}
 			
 			if(callBack) {

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function runSequence(gulp) {
 			var error;
 			if (e && e.err) {
 				error = new gutil.PluginError('run-sequence', { 
-					message: 'An error occured in task "' + e.task + '".'
+					message: 'An error occured in task \'' + e.task + '\'.'
 				});
 			}
 			

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 "use strict";
 
 var colors = require('chalk');
+var gutil = require('gulp-util');
 
 function verifyTaskSets(gulp, taskSets, skipArrays) {
 	if(taskSets.length === 0) {
@@ -49,10 +50,18 @@ function runSequence(gulp) {
 		finish = function(e) {
 			gulp.removeListener('task_stop', onTaskEnd);
 			gulp.removeListener('task_err', onError);
+			
+			var error;
+			if (e && e.err) {
+				error = new gutil.PluginError('run-sequence', { 
+					message: 'An error occured in task "' + e.task + '".'
+				})
+			}
+			
 			if(callBack) {
-				callBack(e && e.err ? e.err : undefined);
-			} else if(e && e.err) {
-				console.log(colors.red('Error running task sequence:'), e.err);
+				callBack(error);
+			} else if(error) {
+				console.log(colors.red(error.toString()));
 			}
 		},
 

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function runSequence(gulp) {
 			if(callBack) {
 				callBack(error);
 			} else if(error) {
-				console.log(colors.red(error.toString()));
+				gutil.log(colors.red(error.toString()));
 			}
 		},
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "orchestrator"
   ],
   "dependencies": {
-    "chalk": "*"
+    "chalk": "*",
+    "gulp-util": "*"
   },
   "devDependencies": {
     "gulp": "*",


### PR DESCRIPTION
run-sequence uses 'task_err' event to handle errors. Gulp does the same. This means that at a bare minimum, if a task has an error where orchestrator emits 'task_err', gulp will report it. Right now, run-sequence is passing this error to its callback. Gulp will re-log this error and in many cases, it re-logs for each nested task. If that error has a callstack, the stack is also logged. This adds a ton of noise to the log. It makes sense then to opt for a more general error message, making the output easier to read and parse as a human.