### PR TITLE
Pass error object to PluginError for better error reporting.

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function runSequence(gulp) {
 			
 			var error;
 			if (e && e.err) {
-				error = new gutil.PluginError('run-sequence(' + e.task + ')', e, {showStack: true});
+				error = new gutil.PluginError('run-sequence(' + e.task + ')', e.err, {showStack: true});
 			}
 			
 			if(callBack) {


### PR DESCRIPTION
PluginError understands the actual error objects better. This will generate a proper error message with the right stack trace.

Properly fixes #65