### PR TITLE
handle orchestration aborted events

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,6 +102,11 @@ function runSequence(gulp) {
 	}
 
 	function onGulpError(e) {
+		// In the case that you call gulp.stop after a successful run,
+		// we will not recieve a task_err or task_stop event. This callback
+		// will finish the run sequence execution in case of an 'orchestration aborted'
+		// even coming from gulp's global error handler. That event is fired in when
+		// gulp.stop is called.
 		if (e.message === 'orchestration aborted') {
 			finish(e);
 		}

--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ function runSequence(gulp) {
 
 	function finish(e) {
 		if (finished) return;
+		finished = true;
 
 		gulp.removeListener('task_stop', onTaskEnd);
 		gulp.removeListener('task_err', onError);
@@ -107,7 +108,7 @@ function runSequence(gulp) {
 		// will finish the run sequence execution in case of an 'orchestration aborted'
 		// even coming from gulp's global error handler. That event is fired in when
 		// gulp.stop is called.
-		if (e.message === 'orchestration aborted') {
+		if(e.message === 'orchestration aborted') {
 			finish(e);
 		}
 	};

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function runSequence(gulp) {
 	}
 
 	function finish(e) {
-		if (finished) return;
+		if(finished) return;
 		finished = true;
 
 		gulp.removeListener('task_stop', onTaskEnd);

--- a/test/main.js
+++ b/test/main.js
@@ -263,7 +263,7 @@ describe('runSequence', function() {
 
 		it('should pass error if gulp execution halted in second execution', function(done) {
 			var stopTask = gulp.task('stopTask', function() {
-				if (stopTask.shouldStop) {
+				if(stopTask.shouldStop) {
 					gulp.stop();
 				}
 			});

--- a/test/main.js
+++ b/test/main.js
@@ -262,7 +262,7 @@ describe('runSequence', function() {
 		})
 
 		it('should pass error if gulp execution halted in second execution', function(done) {
-			const stopTask = gulp.task('stopTask', function() {
+			var stopTask = gulp.task('stopTask', function() {
 				if (stopTask.shouldStop) {
 					gulp.stop();
 				}
@@ -272,11 +272,11 @@ describe('runSequence', function() {
 
 			var outerTask = gulp.task('outerTask', function(cb) {
 				runSequence('task2', ['stopTask', 'task3'], function(err) {
-					if (stopTask.shouldStop) {
+					if(stopTask.shouldStop) {
 						try {
 							should(err).be.ok;
 							err.message.should.equal('orchestration aborted');
-						} catch (e) {
+						} catch(e) {
 							cb();
 							return done(e);
 						}


### PR DESCRIPTION
If running under a watcher, run-sequence will fail to trigger on subsequent calls to gulp.start when gulp.stop is called mid-sequence unless it handles the 'orchestration aborted' error.