### PR TITLE
Scorpiocoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build
 components
 *.orig
 .idea
+package-lock.json
+

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 /*jshint node:true */
 
+//2018-01-02 sc mod: gulp-util deprecation
 //2018-01-02 sc mod: require plugin-error to replace gutil.PluginError
+//2018-01-02 sc mod: require fancy-log to replace gutil.log
 
 "use strict";
 
@@ -8,6 +10,7 @@ var colors = require('chalk');
 //sc mod start
 //var gutil = require('gulp-util');
 var pulginError = require('plugin-error');
+var log = require('fancy-log');
 //sc mod stop
 
 function options() { return module.exports.options }
@@ -92,7 +95,10 @@ function runSequence(gulp) {
 		if(callBack) {
 			callBack(error);
 		} else if(error) {
-			gutil.log(colors.red(error.toString()));
+			//sc mod start
+			//gutil.log(colors.red(error.toString()));
+			log(colors.red(error.toString()));
+			//sc mod stop
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,14 @@
 /*jshint node:true */
 
+//2018-01-02 sc mod: require plugin-error to replace gutil.PluginError
+
 "use strict";
 
 var colors = require('chalk');
-var gutil = require('gulp-util');
+//sc mod start
+//var gutil = require('gulp-util');
+var pulginError = require('plugin-error');
+//sc mod stop
 
 function options() { return module.exports.options }
 
@@ -78,7 +83,10 @@ function runSequence(gulp) {
 
 		var error;
 		if(e && e.err) {
-			error = new gutil.PluginError('run-sequence(' + e.task + ')', e.err, { showStack: options().showErrorStackTrace });
+			//sc mod start
+			//error = new gutil.PluginError('run-sequence(' + e.task + ')', e.err, { showStack: options().showErrorStackTrace });
+			error = new pulginError('run-sequence(' + e.task + ')', e.err, { showStack: options().showErrorStackTrace });
+			//sc mod stop
 		}
 
 		if(callBack) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "dependencies": {
     "chalk": "^1.1.3",
+    "fancy-log": "^1.3.2",
     "gulp-util": "^3.0.8",
     "plugin-error": "^0.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   ],
   "dependencies": {
     "chalk": "^1.1.3",
-    "gulp-util": "^3.0.8"
+    "gulp-util": "^3.0.8",
+    "plugin-error": "^0.1.2"
   },
   "devDependencies": {
     "gulp": "^3.9.1",


### PR DESCRIPTION
Hi there,

Created a hotfix for the gulp-util deprecation issue
Installed dependecies
- plugin-error as replacement for gulp-util.PluginError
- fancy-log as replacement for gulp-util.log

files modified are:
.gitignore 
--- added package-lock.json that occures when using VS code and SourceTree Git manager
package.json
--- added dependencies
index.js
--- mod code 

I hope that my first try is a succes?
my firdst pull-request....lol

kind regards
scorpiocoding - kribo
